### PR TITLE
Have a backup for even newer versions of pip.

### DIFF
--- a/src/releasely/compat.py
+++ b/src/releasely/compat.py
@@ -3,6 +3,11 @@ try:
 
     toml_load = pytoml.load
 except ImportError:
-    from pip._vendor import toml
+    try:
+        from pip._vendor import toml
 
-    toml_load = toml.load
+        toml_load = toml.load
+    except ImportError:
+        from pip._vendor import tomli
+
+        toml_load = tomli.load


### PR DESCRIPTION
I think `toml` was yanked from pip in favor of `tomli`. Not entirely sold on the particulars here, but something in this direction might work.